### PR TITLE
Fix compile warnings

### DIFF
--- a/lib/geo/wkb/encoder.ex
+++ b/lib/geo/wkb/encoder.ex
@@ -41,6 +41,14 @@ defmodule Geo.WKB.Encoder do
 
   def encode!(geom, endian \\ :ndr)
 
+  def do_encode(%Point{coordinates: nil}, :ndr) do
+    {@point, [<<00, 00, 00, 00, 00, 00, 248, 127>>, <<00, 00, 00, 00, 00, 00, 248, 127>>]}
+  end
+
+  def do_encode(%Point{coordinates: nil}, :xdr) do
+    {@point, [<<127, 248, 00, 00, 00, 00, 00, 00>>, <<127, 248, 00, 00, 00, 00, 00, 00>>]}
+  end
+
   for {endian, endian_atom, modifier} <- [{1, :ndr, quote(do: little)}, {0, :xdr, quote(do: big)}] do
     def encode!(geom, unquote(endian_atom)) do
       {type, rest} = do_encode(geom, unquote(endian_atom))
@@ -53,14 +61,6 @@ defmodule Geo.WKB.Encoder do
         end
 
       [unquote(endian), binary, rest]
-    end
-
-    def do_encode(%Point{coordinates: nil}, :ndr) do
-      {@point, [<<00, 00, 00, 00, 00, 00, 248, 127>>, <<00, 00, 00, 00, 00, 00, 248, 127>>]}
-    end
-
-    def do_encode(%Point{coordinates: nil}, :xdr) do
-      {@point, [<<127, 248, 00, 00, 00, 00, 00, 00>>, <<127, 248, 00, 00, 00, 00, 00, 00>>]}
     end
 
     def do_encode(%Point{coordinates: {x, y}}, unquote(endian_atom)) do


### PR DESCRIPTION
This was breaking the build because we were unintentionally duplicating these function clauses (see the `for {endian, endian_atom, modifier} . . .` stuff).