### PR TITLE
Run CI on merge to master

### DIFF
--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -3,7 +3,7 @@ name: Elixir Unit Tests
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -70,8 +70,21 @@ jobs:
 
       - name: Run tests with warnings as errors
         if: ${{ matrix.elixir != '1.11.4' && matrix.elixir != '1.10.4' }} 
-        run: mix test --warnings-as-errors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: mix test --warnings-as-errors
+          new_command_on_retry: mix test --warnings-as-errors --failed
+      
 
       - name: Run tests
         if: ${{ matrix.elixir == '1.11.4' }}
-        run: mix test
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: mix test
+          new_command_on_retry: mix test --failed

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -3,7 +3,7 @@ name: Elixir Quality Checks
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/elixir-retired-packages-check.yml
+++ b/.github/workflows/elixir-retired-packages-check.yml
@@ -3,7 +3,7 @@ name: Elixir Retired Packages Check
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
I had copied these templates from a project where the main branch was named `main`. For the time being, I've just updated the name here to match the project's main branch name of `master`. (Longer term, we should look into what might break in people's workflows if we moved to `main`.)