### PR TITLE
Convert string coordinates to floats, or raise an error

### DIFF
--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -275,4 +275,8 @@ defmodule Geo.JSON.Decoder do
         raise ArgumentError, "expected a numeric coordinate, got: #{inspect(other)}"
     end)
   end
+
+  defp ensure_numeric(other) do
+    raise ArgumentError, "expected a numeric coordinate, got: #{inspect(other)}"
+  end
 end

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -387,6 +387,50 @@ defmodule Geo.JSON.Test do
     assert geom.geometries == []
   end
 
+  test "Decode seamlessly converts coordinates that are numbers-as-strings" do
+    check all(
+            x <- float(),
+            y <- float()
+          ) do
+      json = """
+        {
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": ["#{x}", "#{y}"]
+          },
+          "type": "Feature"
+        }
+      """
+
+      assert %Geo.Point{coordinates: {^x, ^y}} = Jason.decode!(json) |> Geo.JSON.decode!()
+    end
+  end
+
+  test "Decode rejects geometries with non-numeric coordinates" do
+    for {bad_x, bad_y} <- [
+          {" 100.0", "0.0"},
+          {"100.0", "0.0?"},
+          {"100.", "0.0"},
+          {"100.0", nil, "0.0"}
+        ] do
+      json = """
+        {
+          "properties": {},
+          "geometry": {
+            "type": "Point",
+            "coordinates": [#{inspect(bad_x)}, #{inspect(bad_y)}]
+          },
+          "type": "Feature"
+        }
+      """
+
+      assert_raise ArgumentError, fn ->
+        Jason.decode!(json) |> Geo.JSON.decode!()
+      end
+    end
+  end
+
   property "encodes and decodes back to the correct Point struct" do
     check all(
             x <- float(),

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -522,7 +522,7 @@ defmodule Geo.JSON.Test do
 
     geom = Jason.decode!(json) |> Geo.JSON.decode!()
 
-    assert %GeometryCollection{} = geom
+    assert %Geo.GeometryCollection{} = geom
     assert length(geom.geometries) == 2
     assert Enum.all?(geom.geometries, &match?(%Geo.MultiPolygon{}, &1))
     assert geom.properties["id"] == "FLC017"

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -431,6 +431,23 @@ defmodule Geo.JSON.Test do
     end
   end
 
+  test "Decode rejects geometries with garbage coordinates" do
+    json = """
+      {
+        "properties": {},
+        "geometry": {
+          "type": "Point",
+          "coordinates": {"x": 1.0, "y": 2.0}
+        },
+        "type": "Feature"
+      }
+    """
+
+    assert_raise ArgumentError, fn ->
+      Jason.decode!(json) |> Geo.JSON.decode!()
+    end
+  end
+
   property "encodes and decodes back to the correct Point struct" do
     check all(
             x <- float(),


### PR DESCRIPTION
This fixes an issue where we were silently accepting non-numeric coordinates in the GeoJSON decoder, such that you could wind up doing things like decoding a point like `%Geo.Point{coordinates: {"100.0", "-10.0"}}`. This would obviously not have gone well for you later in your processing pipeline.

The fix here, suggested by @LostKobrakai, is to convert those strings to numbers where we can do so unambiguously. While such inputs are clearly invalid, it's easy enough to handle them in the way that the user was hoping that we should probably just do it. In cases where there's any ambiguity at all, we raise an ArgumentError.

Resolves #175