### PR TITLE
Default decoded GeoJSON to SRID 4326 (WGS 84) per the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.0.0 — 2024-09
 
-### Potentially breaking change: Default decoded GeoJSON to SRID 4326 (WGS 84)
+### Potentially breaking change: [Default decoded GeoJSON to SRID 4326 (WGS 84)](https://github.com/felt/geo/pull/219)
 
 This aligns our GeoJSON decoding with [the GeoJSON spec](https://tools.ietf.org/html/rfc7946#section-4) by making all decoded GeoJSON infer the WGS 84 datum (SRID 4326) by default. Whereas previously when you called `Geo.JSON.decode/1` or `decode!/1`, we would return geometries with an `:srid` of `nil`, we now return `srid: 4326`. Likewise when encoding GeoJSON, we explicitly output a `crs` field indicating the datum.
 
@@ -16,7 +16,7 @@ A couple examples of the changes:
 iex> Geo.JSON.decode!(%{"type" => "Point", "coordinates" => [1.0, 2.0]})
 %Geo.Point{
   coordinates: {1.0, 2.0},
-  # Note the default SRID
+  # Note the old default nil SRID!
   srid: nil
 }
 ```
@@ -27,12 +27,12 @@ iex> Geo.JSON.decode!(%{"type" => "Point", "coordinates" => [1.0, 2.0]})
 iex> Geo.JSON.decode!(%{"type" => "Point", "coordinates" => [1.0, 2.0]})
 %Geo.Point{
   coordinates: {1.0, 2.0},
-  # New explicit default
+  # New explicit default of WGS 84
   srid: 4326
 }
 ```
 
-If you were then encode this value again, you'd end up with a new `crs` field in the output GeoJSON:
+If you were to then encode this value again, you'd end up with a new `crs` field in the output GeoJSON:
 
 ```elixir
 iex> %{"type" => "Point", "coordinates" => [1.0, 2.0]}
@@ -49,6 +49,23 @@ iex> %{"type" => "Point", "coordinates" => [1.0, 2.0]}
 This last behavior is the most potentially troublesome. However, we don't have a good way of distinguishing a case where you explicitly had the `crs` set in the input to the decoding function (in which case you would probably also like to have it present in the re-encoded version) compared to one in which it's been inferred.
 
 Thanks to @gworkman for reporting this issue ([#129](https://github.com/felt/geo/issues/129)).
+
+### Potentially breaking change: [Convert string coordinates to floats, or raise an error](https://github.com/felt/geo/pull/218)
+
+This fixes an issue where we were silently accepting non-numeric coordinates in the GeoJSON decoder, such that you could wind up doing things like decoding a point like `%Geo.Point{coordinates: {"100.0", "-10.0"}}`. This would obviously not have gone well for you later in your processing pipeline, and it violates our typespecs.
+
+The fix here, suggested by @LostKobrakai, is to convert those strings to numbers where we can do so unambiguously. While such inputs are clearly invalid, it's easy enough to handle them in the way that the user was hoping that we should probably just do it. In cases where there's any ambiguity at all, we raise an `ArgumentError`.
+
+### Bug fixes in v4.0.0
+
+- [Support GeoJSON Feature object with nested GeometryCollection](https://github.com/felt/geo/pull/194) by new contributor @carstenpiepel (🎉)
+
+### Other changes in v4.0.0
+
+- [Fix typo in the README](https://github.com/felt/geo/pull/197) by @caspg
+- [Fix typo](https://github.com/felt/geo/pull/216) by new contributor @preciz (🎉)
+- [Optional dependency bump for `jason` to v1.4.4](https://github.com/felt/geo/pull/215)
+- Dev dependency bumps for ex_doc, benchee, stream_data
 
 ## v3.6.0 — 2023-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v4.0.0 — 2024-09
+## v4.0.0 — 2024-09-17
 
 ### Potentially breaking change: [Default decoded GeoJSON to SRID 4326 (WGS 84)](https://github.com/felt/geo/pull/219)
 
@@ -56,7 +56,7 @@ This fixes an issue where we were silently accepting non-numeric coordinates in 
 
 The fix here, suggested by @LostKobrakai, is to convert those strings to numbers where we can do so unambiguously. While such inputs are clearly invalid, it's easy enough to handle them in the way that the user was hoping that we should probably just do it. In cases where there's any ambiguity at all, we raise an `ArgumentError`.
 
-### Bug fixes in v4.0.0
+### Other bug fixes in v4.0.0
 
 - [Support GeoJSON Feature object with nested GeometryCollection](https://github.com/felt/geo/pull/194) by new contributor @carstenpiepel (🎉)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ _Note_: If you are looking to do geospatial calculations in memory with Geo's st
 ```elixir
 defp deps do
   [
-    {:geo, "~> 3.6"}
+    {:geo, "~> 4.0"}
   ]
 end
 ```

--- a/lib/geo/json.ex
+++ b/lib/geo/json.ex
@@ -7,13 +7,16 @@ defmodule Geo.JSON do
   so that you can use the resulting GeoJSON structure as a property
   in larger JSON structures.
 
+  Note that, per [the GeoJSON spec](https://tools.ietf.org/html/rfc7946#section-4),
+  all geometries are assumed to use the WGS 84 datum (SRID 4326) by default.
+
   ## Examples
 
       # Using Jason as the JSON parser for these examples
 
       iex> json = "{ \\"type\\": \\"Point\\", \\"coordinates\\": [100.0, 0.0] }"
       ...> json |> Jason.decode!() |> Geo.JSON.decode!()
-      %Geo.Point{coordinates: {100.0, 0.0}, srid: nil}
+      %Geo.Point{coordinates: {100.0, 0.0}, srid: 4326}
 
       iex> geom = %Geo.Point{coordinates: {100.0, 0.0}, srid: nil}
       ...> Jason.encode!(geom)

--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -96,6 +96,9 @@ defmodule Geo.JSON.Decoder do
       true ->
         raise DecodeError, value: geo_json
     end
+    # Per #129, the GeoJSON spec says all GeoJSON coordinates default to SRID 4326 (WGS 84)
+    # https://tools.ietf.org/html/rfc7946#section-4
+    |> default_srid_4326()
   end
 
   @doc """
@@ -279,4 +282,12 @@ defmodule Geo.JSON.Decoder do
   defp ensure_numeric(other) do
     raise ArgumentError, "expected a numeric coordinate, got: #{inspect(other)}"
   end
+
+  defp default_srid_4326(%{srid: nil} = geom), do: %{geom | srid: 4326}
+
+  defp default_srid_4326(%{geometries: geometries} = geom) when is_list(geometries) do
+    %{geom | geometries: Enum.map(geometries, &default_srid_4326/1)}
+  end
+
+  defp default_srid_4326(geom), do: geom
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Geo.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/felt/geo"
-  @version "3.6.0"
+  @version "4.0.0"
 
   def project do
     [


### PR DESCRIPTION
The GeoJSON spec [indicates](https://tools.ietf.org/html/rfc7946#section-4) that all GeoJSON should be assumed to use the WGS 84 datum by default. We should be permissive and allow overriding that datum (as we did previously), but I think the correct behavior here is to make the datum explicit in our decoded `Geo.Geometry.t()` values.

This is a breaking change, but one which I expect to have quite little impact on users. (See the CHANGELOG.md for more.)

Resolves #129