### PR TITLE
Use a custom string_to_float/1 function instead of plain String.to_float for ensure_numeric

### DIFF
--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -262,7 +262,7 @@ defmodule Geo.JSON.Decoder do
 
       str when is_binary(str) ->
         try do
-          String.to_float(str)
+          Geo.Utils.string_to_float!(str)
         catch
           ArgumentError ->
             raise ArgumentError, "expected a numeric coordinate, got the string #{inspect(str)}"

--- a/lib/geo/utils.ex
+++ b/lib/geo/utils.ex
@@ -1,6 +1,31 @@
 defmodule Geo.Utils do
   @moduledoc false
 
+  @spec string_to_float(String.t()) :: {:ok, float()} | {:error, term}
+  def string_to_float(str) when is_binary(str) do
+    case Float.parse(str) do
+      :error ->
+        {:error, :bad_arg}
+
+      {flt, ""} ->
+        {:ok, flt}
+
+      {_flt, _rest} ->
+        {:error, :bad_arg}
+    end
+  end
+
+  @spec string_to_float(String.t()) :: float()
+  def string_to_float!(str) when is_binary(str) do
+    case string_to_float(str) do
+      {:ok, flt} ->
+        flt
+
+      {:error, :bad_arg} ->
+        raise ArgumentError, "given string is not a textual representation of a float"
+    end
+  end
+
   @doc """
   Turns a hex string or an integer of base 16 into its floating point
   representation.

--- a/lib/geo/utils.ex
+++ b/lib/geo/utils.ex
@@ -15,7 +15,7 @@ defmodule Geo.Utils do
     end
   end
 
-  @spec string_to_float(String.t()) :: float()
+  @spec string_to_float!(String.t()) :: float() | no_return()
   def string_to_float!(str) when is_binary(str) do
     case string_to_float(str) do
       {:ok, flt} ->

--- a/test/geo/utils_test.exs
+++ b/test/geo/utils_test.exs
@@ -2,6 +2,23 @@ defmodule Geo.Utils.Test do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
+  describe "string_to_float/1" do
+    test "can convert a textual float" do
+      assert {:ok, +0.0} == Geo.Utils.string_to_float("0.0")
+      assert {:ok, 12.34} == Geo.Utils.string_to_float("12.34")
+    end
+
+    test "can convert a textual integer" do
+      assert {:ok, +0.0} == Geo.Utils.string_to_float("0")
+      assert {:ok, 12.0} == Geo.Utils.string_to_float("12")
+    end
+
+    test "can handle badly formatted float" do
+      assert {:error, :bad_arg} == Geo.Utils.string_to_float("0.x")
+      assert {:error, :bad_arg} == Geo.Utils.string_to_float("11f")
+    end
+  end
+
   test "Hex String to Float Conversion" do
     assert(Geo.Utils.hex_to_float("40000000") == 2.0)
     assert(Geo.Utils.hex_to_float("C0000000") == -2.0)


### PR DESCRIPTION
String.to_float will not handle integer representations, instead Float.parse can be used, I almost wanted to roll something myself until I remembered Float.parse exists.

## Related 

#220