### PR TITLE
Fix ExDoc source ref links not working due to wrong branch name

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,6 +53,7 @@ defmodule Geo.Mixfile do
       extras: ["CHANGELOG.md", "README.md"],
       main: "readme",
       source_url: @source_url,
+      source_ref: "master",
       formatters: ["html"]
     ]
   end


### PR DESCRIPTION
The default branch name for ExDoc links is "main", but this project's primary branch is "master".

This pull request fixes the issue by specifying the correct `:source_ref` option in the ExDoc config.